### PR TITLE
Limit Stack Traces to Avoid Hitting LogDNA Limit

### DIFF
--- a/src/Formatter/SmartJsonFormatter.php
+++ b/src/Formatter/SmartJsonFormatter.php
@@ -5,6 +5,7 @@ class SmartJsonFormatter extends BasicJsonFormatter
 {
     protected $includeStacktraces = true;
     private $ignorePaths          = [];
+    private $stackTraceLimit      = null;
 
     /**
      * Ignore paths are paths to code that will be excluded from the log stack trace output.
@@ -14,6 +15,14 @@ class SmartJsonFormatter extends BasicJsonFormatter
     public function setIgnorePaths(array $ignorePaths): void
     {
         $this->ignorePaths = $ignorePaths;
+    }
+
+    /**
+     * To limit the size of the output you can set a stack trace limit.
+     */
+    public function setStackTrackLimit(int $limit): void
+    {
+        $this->stackTraceLimit = $limit;
     }
 
     /*
@@ -67,7 +76,7 @@ class SmartJsonFormatter extends BasicJsonFormatter
                 'line'     => ($frame['line'] ?? ''),
             ];
 
-            if (count($stack) >= 50) {
+            if ($this->stackTraceLimit !== null && count($stack) > $this->stackTraceLimit) {
                 break;
             }
         }

--- a/src/Formatter/SmartJsonFormatter.php
+++ b/src/Formatter/SmartJsonFormatter.php
@@ -66,6 +66,10 @@ class SmartJsonFormatter extends BasicJsonFormatter
                 'file'     => $file,
                 'line'     => ($frame['line'] ?? ''),
             ];
+
+            if (count($stack) >= 50) {
+                break;
+            }
         }
 
         return $stack;

--- a/src/Formatter/SmartJsonFormatter.php
+++ b/src/Formatter/SmartJsonFormatter.php
@@ -76,7 +76,7 @@ class SmartJsonFormatter extends BasicJsonFormatter
                 'line'     => ($frame['line'] ?? ''),
             ];
 
-            if ($this->stackTraceLimit !== null && count($stack) > $this->stackTraceLimit) {
+            if ($this->stackTraceLimit !== null && count($stack) >= $this->stackTraceLimit) {
                 break;
             }
         }

--- a/tests/Formatter/SmartJsonFormatterTest.php
+++ b/tests/Formatter/SmartJsonFormatterTest.php
@@ -109,6 +109,7 @@ class SmartJsonFormatterTest extends TestCase
         ]);
 
         $formatter = new SmartJsonFormatter;
+        $formatter->setStackTrackLimit(50);
         $formatted = $formatter->format($record);
         $output = json_decode($formatted, true);
 

--- a/tests/Formatter/SmartJsonFormatterTest.php
+++ b/tests/Formatter/SmartJsonFormatterTest.php
@@ -111,7 +111,7 @@ class SmartJsonFormatterTest extends TestCase
         $formatter = new SmartJsonFormatter;
         $formatter->setStackTrackLimit(50);
         $formatted = $formatter->format($record);
-        $output = json_decode($formatted, true);
+        $output    = json_decode($formatted, true);
 
         $this->assertTrue(mb_strlen($formatted) < 32000); // Output lower than LogDNA limit
         $this->assertCount(50, $output['lines'][0]['meta']['exception']['trace']);

--- a/tests/Formatter/SmartJsonFormatterTest.php
+++ b/tests/Formatter/SmartJsonFormatterTest.php
@@ -5,6 +5,7 @@ use Fusions\Monolog\LogDna\Formatter\SmartJsonFormatter;
 use Fusions\Test\Monolog\LogDna\TestHelperTrait;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class SmartJsonFormatterTest extends TestCase
 {
@@ -84,5 +85,34 @@ class SmartJsonFormatterTest extends TestCase
         foreach ($output['lines'][0]['meta']['exception']['trace'] as $trace) {
             $this->assertStringNotContainsString($excludedPath, $trace['file']);
         }
+    }
+
+    public function test_limit_long_traces(): void
+    {
+        $longTrace = [];
+
+        for ($i = 0; $i < 250; $i++) {
+            $longTrace[] = [
+                'class'    => 'MyClass',
+                'function' => 'baz',
+                'args'     => [true, false, 42, 42.42, 'FOO', ['FOO', 'BAR'], new stdClass],
+                'type'     => '->',
+                'file'     => '/my/fake/path/src/MyClass.php',
+                'line'     => 256,
+            ];
+        }
+
+        $this->assertTrue(mb_strlen(json_encode($longTrace)) > 32000); // Stacktrace bigger than LogDNA limit
+
+        $record = $this->getRecord(Logger::INFO, 'This is a test message', [
+            'exception' => $this->getExceptionWithStackTrace('This is a test exception', 42, null, $longTrace),
+        ]);
+
+        $formatter = new SmartJsonFormatter;
+        $formatted = $formatter->format($record);
+        $output = json_decode($formatted, true);
+
+        $this->assertTrue(mb_strlen($formatted) < 32000); // Output lower than LogDNA limit
+        $this->assertCount(50, $output['lines'][0]['meta']['exception']['trace']);
     }
 }

--- a/tests/TestHelperTrait.php
+++ b/tests/TestHelperTrait.php
@@ -25,9 +25,9 @@ trait TestHelperTrait
         ];
     }
 
-    public function getExceptionWithStackTrace(string $message = '', int $code = 0, Throwable $previous = null): Exception
+    public function getExceptionWithStackTrace(string $message = '', int $code = 0, Throwable $previous = null, array $trace = null): Exception
     {
-        return new StackTraceTestException($message, $code, $previous, [
+        return new StackTraceTestException($message, $code, $previous, $trace ?? [
             [
                 'class'    => 'MyClass',
                 'function' => 'baz',


### PR DESCRIPTION
We are hitting the LogDNA limit so i thought it may help if we can set a stack trace limit