### PR TITLE
Correctly handle 32KB metadata parsing behaviour

### DIFF
--- a/src/Handler/LogDnaHandler.php
+++ b/src/Handler/LogDnaHandler.php
@@ -74,9 +74,9 @@ class LogDnaHandler extends AbstractProcessingHandler
 
         /**
          * We need to pretty print the metadata JSON before we check its the size, as LogDNA's 32KB limit applies to the
-         * number bytes of metadata **AFTER** LogDNA's API (Restify) has parsed and pretty formatted the JSON it.
+         * number bytes of metadata JSON **AFTER** LogDNA's API (Restify) has parsed and pretty formatted it.
          *
-         * It **DOES NOT* apply to the number of bytes actually sent in the API request, like you'd expect.
+         * It **DOES NOT* apply to the number of bytes actually sent in the API request as you'd expect.
          *
          * Essentially this is guess work on our part - we're hoping that the size of the JSON pretty printed is roughly
          * the same as the parsing process on LogDNA's end. It's the best we can do under the circumstances.

--- a/src/Handler/LogDnaHandler.php
+++ b/src/Handler/LogDnaHandler.php
@@ -14,8 +14,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class LogDnaHandler extends AbstractProcessingHandler
 {
-    public const LOGDNA_INGESTION_URL = 'https://logs.logdna.com/logs/ingest';
-    public const LOGDNA_BYTE_LIMIT    = 30_000;
+    public const LOGDNA_INGESTION_URL   = 'https://logs.logdna.com/logs/ingest';
+    public const LOGDNA_META_DATA_LIMIT = 30_000;
 
     private $ingestionKey = '';
     private $hostName     = '';
@@ -72,7 +72,7 @@ class LogDnaHandler extends AbstractProcessingHandler
     {
         $body = $record['formatted'];
 
-        if (mb_strlen($body, '8bit') > static::LOGDNA_BYTE_LIMIT) {
+        if (mb_strlen($body, '8bit') > static::LOGDNA_META_DATA_LIMIT) {
             $decodedBody = json_decode($body, true);
 
             $body = json_encode([
@@ -83,11 +83,11 @@ class LogDnaHandler extends AbstractProcessingHandler
                         'app'       => $decodedBody['lines'][0]['app'] ?? '',
                         'level'     => $decodedBody['lines'][0]['level'] ?? '',
                         'meta'      => [
-                            'longException' => mb_substr($body, 0, static::LOGDNA_BYTE_LIMIT, '8bit'),
+                            'longException' => mb_substr($body, 0, static::LOGDNA_META_DATA_LIMIT, '8bit'),
                         ],
                     ],
                 ],
-            ], JSON_PRETTY_PRINT); // LogDNA seems to pretty format the JSON string sent, then check its byte size is under the 32KB limit, so we pretty print here to ensure we don't hit that.
+            ]);
         }
 
         $this->lastBody = $body;

--- a/src/Handler/LogDnaHandler.php
+++ b/src/Handler/LogDnaHandler.php
@@ -95,7 +95,9 @@ class LogDnaHandler extends AbstractProcessingHandler
                         'level'     => $decodedBody['lines'][0]['level'] ?? '',
                         'meta'      => [
                             'truncated' => mb_substr(
-                                json_encode($decodedBody['lines'][0]['meta'], JSON_PRETTY_PRINT), 0, static::LOGDNA_META_DATA_LIMIT,
+                                json_encode($decodedBody['lines'][0]['meta'], JSON_PRETTY_PRINT),
+                                0,
+                                static::LOGDNA_META_DATA_LIMIT,
                                 '8bit'
                             ),
                         ],

--- a/src/Handler/LogDnaHandler.php
+++ b/src/Handler/LogDnaHandler.php
@@ -94,7 +94,7 @@ class LogDnaHandler extends AbstractProcessingHandler
 
         $this->lastResponse = $this->getHttpClient()->request('POST', static::LOGDNA_INGESTION_URL, [
             'headers' => [
-                'Content-Type' => 'application/json',
+                'Content-Type' => 'application/json; charset=UTF-8',
             ],
             'auth' => [
                 $this->ingestionKey, '',

--- a/src/Handler/LogDnaHandler.php
+++ b/src/Handler/LogDnaHandler.php
@@ -15,13 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 class LogDnaHandler extends AbstractProcessingHandler
 {
     public const LOGDNA_INGESTION_URL = 'https://logs.logdna.com/logs/ingest';
-
-    /**
-     * The documented limit is 32KB. In reality though anything over 25KB is lost forever,
-     * anything between 20KB to 25KB is saved but unparsed, and anything below 20KB is saved and parsed.
-     * We go slightly lower than 20KB for some leeway.
-     */
-    public const LOGDNA_BYTE_LIMIT    = 18_000;
+    public const LOGDNA_BYTE_LIMIT    = 30_000;
 
     private $ingestionKey = '';
     private $hostName     = '';
@@ -93,7 +87,7 @@ class LogDnaHandler extends AbstractProcessingHandler
                         ],
                     ],
                 ],
-            ]);
+            ], JSON_PRETTY_PRINT); // LogDNA seems to pretty format the JSON string sent, then check its byte size is under the 32KB limit, so we pretty print here to ensure we don't hit that.
         }
 
         $this->lastBody = $body;

--- a/src/Handler/LogDnaHandler.php
+++ b/src/Handler/LogDnaHandler.php
@@ -73,7 +73,7 @@ class LogDnaHandler extends AbstractProcessingHandler
         $body = $record['formatted'];
 
         /**
-         * We need to pretty print the metadata JSON before we check its the size, as LogDNA's 32KB limit applies to the
+         * We need to pretty print the metadata JSON before we check its size, as LogDNA's 32KB limit applies to the
          * number bytes of metadata JSON **AFTER** LogDNA's API (Restify) has parsed and pretty formatted it.
          *
          * It **DOES NOT* apply to the number of bytes actually sent in the API request as you'd expect.

--- a/src/Handler/LogDnaHandler.php
+++ b/src/Handler/LogDnaHandler.php
@@ -76,7 +76,7 @@ class LogDnaHandler extends AbstractProcessingHandler
          * We need to pretty print the metadata JSON before we check its size, as LogDNA's 32KB limit applies to the
          * number bytes of metadata JSON **AFTER** LogDNA's API (Restify) has parsed and pretty formatted it.
          *
-         * It **DOES NOT* apply to the number of bytes actually sent in the API request as you'd expect.
+         * It **DOES NOT** apply to the number of bytes actually sent in the API request as you'd expect.
          *
          * Essentially this is guess work on our part - we're hoping that the size of the JSON pretty printed is roughly
          * the same as the parsing process on LogDNA's end. It's the best we can do under the circumstances.

--- a/tests/Handler/LogDnaHandlerTest.php
+++ b/tests/Handler/LogDnaHandlerTest.php
@@ -109,7 +109,7 @@ class LogDnaHandlerTest extends TestCase
             ];
         }
 
-        $this->assertGreaterThan(20_000, mb_strlen(json_encode($longTrace), '8bit'));
+        $this->assertGreaterThan(30_000, mb_strlen(json_encode($longTrace), '8bit'));
 
         $logger->info('This is a test message', [
             'exception' => $this->getExceptionWithStackTrace('This is a test exception', 42, null, $longTrace),
@@ -125,7 +125,7 @@ class LogDnaHandlerTest extends TestCase
         );
 
         $decodedBody = json_decode($handler->getLastBody(), true);
-        $this->assertSame(18_000, mb_strlen($decodedBody['lines'][0]['meta']['longException'], '8bit'));
+        $this->assertSame(30_000, mb_strlen($decodedBody['lines'][0]['meta']['longException'], '8bit'));
     }
 
     public function assertJsonFileEqualsJsonStringIgnoring(string $expectedFile, string $json, array $ignoring = []): void

--- a/tests/Handler/LogDnaHandlerTest.php
+++ b/tests/Handler/LogDnaHandlerTest.php
@@ -97,7 +97,7 @@ class LogDnaHandlerTest extends TestCase
 
         $longTrace = [];
 
-        while (mb_strlen(json_encode($longTrace, JSON_PRETTY_PRINT), '8bit') <= 50_000) {
+        while (mb_strlen(json_encode($longTrace), '8bit') <= 50_000) {
             $longTrace[] = [
                 'class'    => 'MyClass',
                 'function' => 'baz',
@@ -108,7 +108,7 @@ class LogDnaHandlerTest extends TestCase
             ];
         }
 
-        $this->assertGreaterThan(30_000, mb_strlen(json_encode($longTrace, JSON_PRETTY_PRINT), '8bit'));
+        $this->assertGreaterThan(30_000, mb_strlen(json_encode($longTrace), '8bit'));
 
         $logger->info('This is a test message', [
             'exception' => $this->getExceptionWithStackTrace('This is a test exception', 42, null, $longTrace),

--- a/tests/Handler/LogDnaHandlerTest.php
+++ b/tests/Handler/LogDnaHandlerTest.php
@@ -54,7 +54,6 @@ class LogDnaHandlerTest extends TestCase
             'exception' => $this->getExceptionWithStackTrace(),
         ]);
 
-        // Response.
         $response = $handler->getLastResponse();
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('{ "status": "ok" }', $response->getBody()->getContents());
@@ -98,7 +97,7 @@ class LogDnaHandlerTest extends TestCase
 
         $longTrace = [];
 
-        while (mb_strlen(json_encode($longTrace), '8bit') <= 50_000) {
+        while (mb_strlen(json_encode($longTrace, JSON_PRETTY_PRINT), '8bit') <= 50_000) {
             $longTrace[] = [
                 'class'    => 'MyClass',
                 'function' => 'baz',
@@ -109,7 +108,7 @@ class LogDnaHandlerTest extends TestCase
             ];
         }
 
-        $this->assertGreaterThan(30_000, mb_strlen(json_encode($longTrace), '8bit'));
+        $this->assertGreaterThan(30_000, mb_strlen(json_encode($longTrace, JSON_PRETTY_PRINT), '8bit'));
 
         $logger->info('This is a test message', [
             'exception' => $this->getExceptionWithStackTrace('This is a test exception', 42, null, $longTrace),
@@ -121,11 +120,11 @@ class LogDnaHandlerTest extends TestCase
         $this->assertJsonFileEqualsJsonStringIgnoring(
             __DIR__ . '/../fixtures/long-logdna-body.json',
             $handler->getLastBody(),
-            ['timestamp', 'file', 'longException']
+            ['timestamp', 'file', 'truncated']
         );
 
         $decodedBody = json_decode($handler->getLastBody(), true);
-        $this->assertSame(30_000, mb_strlen($decodedBody['lines'][0]['meta']['longException'], '8bit'));
+        $this->assertSame(30_000, mb_strlen($decodedBody['lines'][0]['meta']['truncated'], '8bit'));
     }
 
     public function assertJsonFileEqualsJsonStringIgnoring(string $expectedFile, string $json, array $ignoring = []): void

--- a/tests/fixtures/long-logdna-body.json
+++ b/tests/fixtures/long-logdna-body.json
@@ -6,7 +6,7 @@
       "app": "test",
       "level": "INFO",
       "meta": {
-        "longException": "--IGNORED--"
+        "truncated": "--IGNORED--"
       }
     }
   ]


### PR DESCRIPTION
I got to the bottom of this issue with LogDNA. Essentially the 32KB metadata limit in their API documentation is misleading. It doesn't apply the number of bytes you send in the API request (as you'd expect), but how many bytes there are after they've parsed it on their end. So basically all we can do is pretty print the JSON and see if it's under the 32KB (or 30KB, to be safe) limit.