### PR TITLE
Switch to Alpine-based PHP CLI image

### DIFF
--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,5 +1,5 @@
-FROM php:7.4.15-cli
+FROM php:7.4.15-cli-alpine
 
-RUN apt-get update && apt-get install -yqq git zip unzip p7zip-full
+RUN apk add --update --no-cache git openssh zip unzip p7zip
 RUN cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/monolog-logdna
+++ b/monolog-logdna
@@ -21,7 +21,7 @@ if [ $# -gt 0 ]; then
     if [ "$1" == "shell" ]; then
         shift 1
 
-        docker run -it --rm --name monolog-logdna --volume "$PWD":/var/www/vhosts/monolog-logdna --workdir /var/www/vhosts/monolog-logdna $PHP_CLI_IMAGE bash
+        docker run -it --rm --name monolog-logdna --volume "$PWD":/var/www/vhosts/monolog-logdna --workdir /var/www/vhosts/monolog-logdna $PHP_CLI_IMAGE sh
 
     # Execute PHP CS Fixer...
     elif [ "$1" == "fix" ]; then


### PR DESCRIPTION
Given how little there is in this image, we may as well slim it down and switch to an Alpine based one.

The final image here is approx 100MB vs the approx 800MB Debian-based one.